### PR TITLE
ZO-523: Integrate seleniumwire aside selenium for requests headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'prometheus_client',
         'pytest',
         'selenium',
+        'selenium-wire',
         'setuptools',
     ],
     entry_points={

--- a/src/zeit/nightwatch/pytest.py
+++ b/src/zeit/nightwatch/pytest.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 import zeit.nightwatch.prometheus
+import zeit.nightwatch.seleniumwire
 
 
 def pytest_addoption(parser):
@@ -33,6 +34,24 @@ def selenium_session(request, nightwatch_config):
     config = nightwatch_config.get('selenium', {})
     config.setdefault('headless', headless)
     browser = zeit.nightwatch.WebDriverChrome(**config)
+    request.addfinalizer(browser.quit)
+    return browser
+
+
+@pytest.fixture
+def seleniumwire(seleniumwire_session):
+    """Testbrowser using `selenium` & Chrome webdriver"""
+    yield seleniumwire_session
+    seleniumwire_session.delete_all_cookies()
+
+
+@pytest.fixture(scope='session')
+def seleniumwire_session(request, nightwatch_config):
+    """Setup for `selenium` based testbrowser (not intended for direct use)"""
+    headless = not request.config.getoption('--selenium-visible')
+    config = nightwatch_config.get('selenium', {})
+    config.setdefault('headless', headless)
+    browser = zeit.nightwatch.seleniumwire.WebDriverChrome(**config)
     request.addfinalizer(browser.quit)
     return browser
 

--- a/src/zeit/nightwatch/seleniumwire.py
+++ b/src/zeit/nightwatch/seleniumwire.py
@@ -1,0 +1,52 @@
+from selenium.common.exceptions import TimeoutException
+from seleniumwire.webdriver.options import Options
+from selenium.webdriver.support.ui import WebDriverWait
+import seleniumwire.webdriver
+
+
+class WebDriverChrome(seleniumwire.webdriver.Chrome):
+
+    default_options = [
+        'disable-gpu',
+    ]
+
+    def __init__(
+            self, baseurl, timeout=30, sso_url=None, headless=True,
+            window='1200x800', user_agent='Mozilla/ZONFrontendMonitoring',
+            *args, **kw):
+        self.baseurl = baseurl
+        self.sso_url = sso_url
+        self.timeout = timeout
+        opts = Options()
+        for x in self.default_options:
+            opts.add_argument(x)
+        if headless:
+            opts.add_argument('headless')
+        opts.add_argument('user-agent=[%s]' % user_agent)
+        opts.add_argument('window-size=%s' % window)
+
+        kw['options'] = opts
+        super().__init__(*args, **kw)
+
+    def get(self, url):
+        if url.startswith('/'):
+            url = self.baseurl + url
+        super().get(url)
+
+    def wait(self, condition, timeout=None):
+        if timeout is None:
+            timeout = self.timeout
+        try:
+            WebDriverWait(self, timeout).until(condition)
+        except TimeoutException as e:
+            raise AssertionError() from e
+
+    def sso_login(self, username, password, url=None):
+        if url is None:
+            url = self.sso_url
+        if url is None:
+            raise ValueError('No url given and no sso_url configured')
+        self.get(url)
+        self.find_element_by_id('login_email').send_keys(username)
+        self.find_element_by_id('login_pass').send_keys(password)
+        self.find_element_by_css_selector('input.submit-button.log').click()

--- a/src/zeit/nightwatch/seleniumwire.py
+++ b/src/zeit/nightwatch/seleniumwire.py
@@ -1,5 +1,4 @@
 from selenium.common.exceptions import TimeoutException
-from seleniumwire.webdriver.options import Options
 from selenium.webdriver.support.ui import WebDriverWait
 import seleniumwire.webdriver
 
@@ -17,7 +16,7 @@ class WebDriverChrome(seleniumwire.webdriver.Chrome):
         self.baseurl = baseurl
         self.sso_url = sso_url
         self.timeout = timeout
-        opts = Options()
+        opts = seleniumwire.webdriver.ChromeOptions()
         for x in self.default_options:
             opts.add_argument(x)
         if headless:

--- a/src/zeit/nightwatch/seleniumwire.py
+++ b/src/zeit/nightwatch/seleniumwire.py
@@ -36,7 +36,7 @@ class WebDriverChrome(seleniumwire.webdriver.Chrome):
         if timeout is None:
             timeout = self.timeout
         try:
-            WebDriverWait(self, timeout).until(condition)
+            return WebDriverWait(self, timeout).until(condition)
         except TimeoutException as e:
             raise AssertionError() from e
 


### PR DESCRIPTION
Die Integration von Seleniumwire erlaubt das benutzen von Request-Headern mittels Selenium wie wir es bei ZOCA benötigen.

Hier wird Authorization mit der Azure Id gesetzt
https://github.com/ZeitOnline/zoca/blob/ZO-523/smoketest/test_endtoend.py#L81

Außerdem kann man mit Selenium-Wire auf Hintergrund-Requests warten
https://github.com/ZeitOnline/zoca/blob/ZO-523/smoketest/test_endtoend.py#L81
