### PR TITLE
ZO-712: Set referer explicitly during sso_login, required for csrf validation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.nightwatch changes
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- ZO-712: Set referer explicitly during sso_login, required for csrf validation
 
 
 1.4.1 (2021-10-27)

--- a/src/zeit/nightwatch/requests.py
+++ b/src/zeit/nightwatch/requests.py
@@ -124,7 +124,7 @@ class Browser(mechanicalsoup.StatefulBrowser):
         self.select_form()
         self.form['email'] = username
         self.form['pass'] = password
-        return self.submit()
+        return self.submit(headers={"referer": url})
 
 
 class LazySoupBrowserState(_BrowserState):


### PR DESCRIPTION
## Was erledigt dieser PR?
Die CSRF-Token-Validierung von Pyramid ueberprueft den Referer, wenn HTTPS verwendet wird. Da dieser offenbar von der Browser-Komponente nicht mitgesendet wird, muessen wir ihn explizit senden.

## Wie wird getestet?
Ich hab ne gute Stunde rumexperimentiert wie man das sivinnvoll testen kann, hab aber entnervt aufgegeben, weil ich a) nicht wollte, dass wir tatsaechlich echte requests rausschicken und b) dann so viel weggemoeckt werden muesste, dass wir am ende nur noch testen, ob ein parameter durchgereicht wird... ja also nee...

Ich hatb's dann von Hand direkt in der smoketest-Integration von zeit.web.member mit nem lokalen zeit.nightwatch ueberprueft und fuer gut befunden. Wenn dir das zu schwammig ist, lass uns nochmal ueber ein grundsaetzliches Testsetup sprechen. Fuer sso_login etc. haben wir hier im Moment sowieso noch ueberhaupt keinen Test.

## Giphy
![](https://media.giphy.com/media/eSgUxM1lzE4YYL4A9O/giphy.gif)