### PR TITLE
ZO-523: Return WebElement after selenium wait

### DIFF
--- a/src/zeit/nightwatch/selenium.py
+++ b/src/zeit/nightwatch/selenium.py
@@ -37,7 +37,7 @@ class Convenience:
         if timeout is None:
             timeout = self.timeout
         try:
-            WebDriverWait(self, timeout).until(condition)
+            return WebDriverWait(self, timeout).until(condition)
         except TimeoutException as e:
             raise AssertionError() from e
 


### PR DESCRIPTION
Man kann einfach das WebElement nach dem Warten weiter verwenden und braucht nicht noch einmal ein find_element benutzen. Hier das Bsp. aus der Doku `el = WebDriverWait(driver).until(lambda d: d.find_element_by_tag_name("p"))` https://www.selenium.dev/documentation/webdriver/waits/#explicit-wait

Da kommt der gleiche Typ WebElement heraus wie bei find_element. Das hatte Andreas und ich hier mal versteckt https://github.com/ZeitOnline/zeit.nightwatch/pull/4/commits/feefaa7d16599c24ce4f4532427c2c45e1b05d33
 