### PR TITLE
ZO-1513: Fix removed find_element syntax

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.nightwatch changes
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- ZO-1513: Fix dremoved find element functions.
 
 
 1.5.0 (2022-03-25)

--- a/src/zeit/nightwatch/selenium.py
+++ b/src/zeit/nightwatch/selenium.py
@@ -1,5 +1,6 @@
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 import selenium.webdriver
 
@@ -47,9 +48,9 @@ class Convenience:
         if url is None:
             raise ValueError('No url given and no sso_url configured')
         self.get(url)
-        self.find_element_by_id('login_email').send_keys(username)
-        self.find_element_by_id('login_pass').send_keys(password)
-        self.find_element_by_css_selector('input.submit-button.log').click()
+        self.find_element(By.ID, 'login_email').send_keys(username)
+        self.find_element(By.ID, 'login_pass').send_keys(password)
+        self.find_element(By.CSS_SELECTOR, 'input.submit-button.log').click()
 
 
 class WebDriverChrome(Convenience, selenium.webdriver.Chrome):


### PR DESCRIPTION
Hier im nightwatch aufgefallen https://ci.zeit.de/job/nightwatch_zoca_production/83697/testReport/(root)/test_endtoend/test_comment_should_be_acceptable_and_rejectable/


`Fehlermeldung
AttributeError: 'ProxiedWebDriverChrome' object has no attribute 'find_element_by_id'
Stacktrace
Traceback (most recent call last):
  File "/srv/jenkins/work/workspace/nightwatch_zoca_production/smoketest/test_endtoend.py", line 516, in test_comment_should_be_acceptable_and_rejectable
    s = sso_login_selenium()
  File "/srv/jenkins/work/workspace/nightwatch_zoca_production/smoketest/test_endtoend.py", line 71, in login
    s.sso_login(zoca_user['name'], zoca_user['password'])
  File "/srv/jenkins/.local/share/virtualenvs/smoketest-KBdWxD79/lib/python3.9/site-packages/zeit/nightwatch/selenium.py", line 50, in sso_login
    self.find_element_by_id('login_email').send_keys(username)
AttributeError: 'ProxiedWebDriverChrome' object has no attribute 'find_element_by_id'`