### PR TITLE
ENG-160: add redirect to sso_login wait_for_url and try testing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,3 +156,9 @@ Here's an output example, formatted for readability (in reality, each test produ
       "test_outcome": "passed",
       "system_log": "11:37:40 INFO  [zeit.nightwatch.requests][MainThread] > POST http://example.com/something\n..."
     }
+
+
+Development and testing
+=======================
+
+Pull requests will run tests in workflow via `bin/test` and do test_basics.py. The two tests from test_sso_login.py will be skipped. These two tests will be only done locally if you have set your vault token and testing credentials are setup.

--- a/bin/test
+++ b/bin/test
@@ -10,4 +10,8 @@ if [[ $DIR/Pipfile.lock -nt $DIR/.pipenv.success ]]; then
     touch $DIR/.pipenv.success
 fi
 
+vault token lookup > /dev/null
+export NORMAL_USERNAME=$(vault read -field name zon/v1/sso/production/testing/reading/normal)
+export NORMAL_PASSWORD=$(vault read -field password zon/v1/sso/production/testing/reading/normal)
+
 exec pipenv run hatch run pytest "$@"

--- a/bin/test
+++ b/bin/test
@@ -10,8 +10,9 @@ if [[ $DIR/Pipfile.lock -nt $DIR/.pipenv.success ]]; then
     touch $DIR/.pipenv.success
 fi
 
-vault token lookup > /dev/null
-export NORMAL_USERNAME=$(vault read -field name zon/v1/sso/production/testing/reading/normal)
-export NORMAL_PASSWORD=$(vault read -field password zon/v1/sso/production/testing/reading/normal)
-
+if vault token lookup > /dev/null 2>&1 ; then
+    export NORMAL_USERNAME=$(vault read -field name zon/v1/sso/production/testing/reading/normal)
+    export NORMAL_PASSWORD=$(vault read -field password zon/v1/sso/production/testing/reading/normal)
+    echo "Setup vault credentials for testing login form"
+fi
 exec pipenv run hatch run pytest "$@"

--- a/src/zeit/nightwatch/playwright.py
+++ b/src/zeit/nightwatch/playwright.py
@@ -1,8 +1,14 @@
+from urllib.parse import parse_qs, urljoin, urlparse
+
 from playwright.sync_api._generated import Page
 
 
 def sso_login(self, url, username, password):
     self.goto(url)
+    query_params = parse_qs(urlparse(url).query)
+    redirect_url_list = query_params.get("url")
+    redirect_uri_list = query_params.get("redirect_uri")
+
     if self.locator("#kc-login").count() == 1:
         self.locator("#username").fill(username)
         self.locator("#password").fill(password)
@@ -11,7 +17,14 @@ def sso_login(self, url, username, password):
         self.locator("#login_email").fill(username)
         self.locator("#login_pass").fill(password)
         self.locator("input.submit-button.log").click()
-    self.wait_for_url("**/konto")
+
+    if redirect_url_list or redirect_uri_list:
+        redirect_list = redirect_url_list or redirect_uri_list
+        redirect = redirect_list.pop()
+        target = urljoin(redirect, urlparse(redirect).path)
+        self.wait_for_url(target + "**")
+    else:
+        self.wait_for_url("**/konto")
 
 
 Page.sso_login = sso_login

--- a/src/zeit/nightwatch/playwright.py
+++ b/src/zeit/nightwatch/playwright.py
@@ -5,9 +5,7 @@ from playwright.sync_api._generated import Page
 
 def sso_login(self, url, username, password):
     self.goto(url)
-    query_params = parse_qs(urlparse(url).query)
-    redirect_url_list = query_params.get("url")
-    redirect_uri_list = query_params.get("redirect_uri")
+    redirect_url_list = parse_qs(urlparse(url).query).get("url")
 
     if self.locator("#kc-login").count() == 1:
         self.locator("#username").fill(username)
@@ -18,9 +16,8 @@ def sso_login(self, url, username, password):
         self.locator("#login_pass").fill(password)
         self.locator("input.submit-button.log").click()
 
-    if redirect_url_list or redirect_uri_list:
-        redirect_list = redirect_url_list or redirect_uri_list
-        redirect = redirect_list.pop()
+    if redirect_url_list:
+        redirect = redirect_url_list.pop()
         target = urljoin(redirect, urlparse(redirect).path)
         self.wait_for_url(target + "**")
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def nightwatch_config():
+    return {
+        "browser": {
+            "baseurl": "https://httpbin.org",
+            "sso_url": "https://meine.zeit.de/anmelden",
+            "user_agent": "Mozilla/ZONFrontendMonitoring",
+        },
+        "normal_username": os.environ.get("NORMAL_USERNAME"),
+        "normal_password": os.environ.get("NORMAL_PASSWORD"),
+    }
+
+
+@pytest.fixture(scope="session")
+def browser_context_args(playwright, nightwatch_config):
+    return {
+        "base_url": nightwatch_config["browser"]["baseurl"],
+        "user_agent": nightwatch_config["browser"]["user_agent"],
+    }

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -2,11 +2,6 @@ import pytest
 
 
 @pytest.fixture(scope="session")
-def nightwatch_config():
-    return {"browser": {"baseurl": "https://httpbin.org"}}
-
-
-@pytest.fixture(scope="session")
 def base_url(nightwatch_config):
     return nightwatch_config.get("browser", {}).get("baseurl")
 

--- a/tests/test_sso_login.py
+++ b/tests/test_sso_login.py
@@ -1,0 +1,56 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def nightwatch_config():
+    return {
+        "browser": {
+            "new_sso_url": "https://login.zeit.de/realms/zeit-online-public/protocol/openid-connect/auth?client_id=member&response_type=code&scope=openid&nonce=6JoG2RI4t3q7fAz8&state=n4Ny98ojp2KYWn81",
+            "sso_url": "https://meine.zeit.de/anmelden",
+            "user_agent": "Mozilla/ZONFrontendMonitoring",
+        },
+        "normal_username": os.environ.get("NORMAL_USERNAME"),
+        "normal_password": os.environ.get("NORMAL_PASSWORD"),
+    }
+
+
+@pytest.fixture(scope="session")
+def browser_context_args(playwright, nightwatch_config):
+    return {
+        "user_agent": nightwatch_config["browser"]["user_agent"],
+    }
+
+
+def test_playwright_sso_login_konto(nightwatch_config, page):
+    page.sso_login(
+        nightwatch_config["browser"]["sso_url"],
+        nightwatch_config["normal_username"],
+        nightwatch_config["normal_password"],
+    )
+    assert page.locator("#main").get_by_text("Mein Konto")
+
+
+def test_playwright_sso_login_redirect_article(nightwatch_config, page):
+    article = (
+        "https://www.zeit.de/2020/54/hackerangriff-us-regierung-russland-solarwinds-cyberkrieg"
+    )
+    page.sso_login(
+        f"{nightwatch_config['browser']['sso_url']}?url={article}",
+        nightwatch_config["normal_username"],
+        nightwatch_config["normal_password"],
+    )
+    assert page.locator("h1").get_by_text("Offenes Geheimnis")
+
+
+def test_playwright_new_sso_login_redirect_article(nightwatch_config, page):
+    article = (
+        "https://www.zeit.de/2020/54/hackerangriff-us-regierung-russland-solarwinds-cyberkrieg"
+    )
+    page.sso_login(
+        f"{nightwatch_config['browser']['new_sso_url']}&redirect_uri={article}",
+        nightwatch_config["normal_username"],
+        nightwatch_config["normal_password"],
+    )
+    assert page.locator("h1").get_by_text("Offenes Geheimnis")

--- a/tests/test_sso_login.py
+++ b/tests/test_sso_login.py
@@ -1,28 +1,3 @@
-import os
-
-import pytest
-
-
-@pytest.fixture(scope="session")
-def nightwatch_config():
-    return {
-        "browser": {
-            "new_sso_url": "https://login.zeit.de/realms/zeit-online-public/protocol/openid-connect/auth?client_id=member&response_type=code&scope=openid&nonce=6JoG2RI4t3q7fAz8&state=n4Ny98ojp2KYWn81",
-            "sso_url": "https://meine.zeit.de/anmelden",
-            "user_agent": "Mozilla/ZONFrontendMonitoring",
-        },
-        "normal_username": os.environ.get("NORMAL_USERNAME"),
-        "normal_password": os.environ.get("NORMAL_PASSWORD"),
-    }
-
-
-@pytest.fixture(scope="session")
-def browser_context_args(playwright, nightwatch_config):
-    return {
-        "user_agent": nightwatch_config["browser"]["user_agent"],
-    }
-
-
 def test_playwright_sso_login_konto(nightwatch_config, page):
     page.sso_login(
         nightwatch_config["browser"]["sso_url"],
@@ -38,18 +13,6 @@ def test_playwright_sso_login_redirect_article(nightwatch_config, page):
     )
     page.sso_login(
         f"{nightwatch_config['browser']['sso_url']}?url={article}",
-        nightwatch_config["normal_username"],
-        nightwatch_config["normal_password"],
-    )
-    assert page.locator("h1").get_by_text("Offenes Geheimnis")
-
-
-def test_playwright_new_sso_login_redirect_article(nightwatch_config, page):
-    article = (
-        "https://www.zeit.de/2020/54/hackerangriff-us-regierung-russland-solarwinds-cyberkrieg"
-    )
-    page.sso_login(
-        f"{nightwatch_config['browser']['new_sso_url']}&redirect_uri={article}",
         nightwatch_config["normal_username"],
         nightwatch_config["normal_password"],
     )

--- a/tests/test_sso_login.py
+++ b/tests/test_sso_login.py
@@ -1,3 +1,11 @@
+import os
+
+import pytest
+
+
+@pytest.mark.skipif(
+    os.environ.get("NORMAL_USERNAME") is None, reason="Just for local testing with vault token"
+)
 def test_playwright_sso_login_konto(nightwatch_config, page):
     page.sso_login(
         nightwatch_config["browser"]["sso_url"],
@@ -7,6 +15,9 @@ def test_playwright_sso_login_konto(nightwatch_config, page):
     assert page.locator("#main").get_by_text("Mein Konto")
 
 
+@pytest.mark.skipif(
+    os.environ.get("NORMAL_USERNAME") is None, reason="Just for local testing with vault token"
+)
 def test_playwright_sso_login_redirect_article(nightwatch_config, page):
     article = (
         "https://www.zeit.de/2020/54/hackerangriff-us-regierung-russland-solarwinds-cyberkrieg"


### PR DESCRIPTION
Der erste Commit ist lokal für ~alle drei~ beide Fälle mit Friedbert verdrahtet geprüft. Also in Friedbert zeit.nightwatch mit Pipenv lokal installiert.

zeit.web/smoketests/Pipfile:
```
diff --git a/smoketest/Pipfile b/smoketest/Pipfile
index 7e8199f214..90b4254ec1 100644
--- a/smoketest/Pipfile
+++ b/smoketest/Pipfile
@@ -4,9 +4,11 @@ verify_ssl = true
 name = "pypi"

 [packages]
-"zeit.nightwatch" = "*"
 "zeit.msal" = "*"
 decorator = "*"
+"zeit.nightwatch" = {file = "../../../../../zeit.nightwatch", editable = true}

 [requires]
 python_version = "3"
```


~Wenn wir bald von meine.zeit auf login.zeit wechseln ändert sich der Parameter für den Redirect von `url` zu `redirect_uri`~

~Die neue [Login-Url](https://github.com/ZeitOnline/zeit.nightwatch/compare/ENG-160?expand=1#diff-7d232984731f60a2bff314631f46f73db8fcef77cde633b3412466387f69ded5R10) benötigt - soweit ich das testen konnte - alle Parameter. Die entstammt einem Klick auf Anmelden in Staging, funktioniert angepasst aber auch für Production. Wenn jemand weiß wie wir das elegant dynamisch besorgen können, gerne aufklären. Wenn ich das richtig verstehe, ist das mit diesem Satz aus der Warnungsbox [hier](https://docs.zeit.de/login/switch/) gemeint:~

~> Sobald der Umweg über meine.zeit.de wegfällt, muss eine andere Lösung dafür gefunden werden.~

Die Irrungen des durchgestrichenen Text [hiermit](https://github.com/ZeitOnline/zeit.nightwatch/pull/19/commits/77f8b07b81e75f5f1c7130908333d75a452f08e3) sind entfernt.

Die Test hängen von den Vault Secrects des `normal_users` leser-moderiert@example.com ab und können lokal durch das [Setzen der Umgebungsvariablen](https://github.com/ZeitOnline/zeit.nightwatch/compare/ENG-160?expand=1#diff-4e821476d5e4f5626c6f9fca337a47afe96a5e3daf23bccb02ad0bb109a9a407R14)  absolviert werden.

~Wen diese Test eurer Zustimmung haben müssen wir zeit.nightwatch noch Zugriff  in den Workflows verschaffen.~
Ich hab mir das mit Andi angeschaut und wir kamen auf die Idee, dass die Login Tests ganz praktisch sein können, wenn man dran arbeitet lokal, im Workflow ohne Vault aber geskipped werden.